### PR TITLE
feat: Add Pi 5 pwmfan RPM and PWM monitoring

### DIFF
--- a/src/services/pi_stats/README.md
+++ b/src/services/pi_stats/README.md
@@ -33,6 +33,17 @@ usage is a nested map of path to usage percentage, for example:
 Unavailable paths are logged and omitted from that sample without stopping the rest
 of the stats payload.
 
+When a Pi 5 Active Cooler (or compatible) exposes a `pwmfan` hwmon device, the
+payload also includes:
+
+| Key | Unit | Source |
+|-----|------|--------|
+| `fan_speed_rpm` | RPM | `/sys/class/hwmon/*/fan1_input` |
+| `fan_pwm_percent` | % | `/sys/class/hwmon/*/pwm1` scaled from 0–255 |
+
+These keys are omitted entirely on hosts without `pwmfan` (and for a sample if the
+sysfs read fails).
+
 ## MQTT Discovery
 
 On connect, `pi_stats` publishes a retained device-discovery payload to:
@@ -44,6 +55,7 @@ That creates one Home Assistant device containing:
 - Fixed sensors with stable IDs (`sensor.<hostname>_cpu_usage`,
   `sensor.<hostname>_wg_scripts_version`, etc.)
 - One disk-usage sensor per `DISK_USAGE_PATHS` entry
+- Fan Speed / Fan PWM sensors when `pwmfan` hwmon is detected at startup
 
 Disk entity IDs use path slugs:
 

--- a/src/services/pi_stats/discovery.py
+++ b/src/services/pi_stats/discovery.py
@@ -228,6 +228,33 @@ def _fixed_components(hostname: str) -> dict[str, dict[str, Any]]:
     return {component["unique_id"]: component for component in sensors}
 
 
+def _fan_components(hostname: str) -> dict[str, dict[str, Any]]:
+    """Build fan sensors for hosts with a Pi 5 pwmfan hwmon device."""
+    sensors = [
+        _sensor_component(
+            hostname=hostname,
+            metric="fan_speed",
+            name="Fan Speed",
+            value_template="{{ value_json.fan_speed_rpm }}",
+            icon="mdi:fan",
+            force_update=True,
+            unit_of_measurement="RPM",
+            state_class="measurement",
+        ),
+        _sensor_component(
+            hostname=hostname,
+            metric="fan_pwm",
+            name="Fan PWM",
+            value_template="{{ value_json.fan_pwm_percent }}",
+            icon="mdi:fan-speed-1",
+            force_update=True,
+            unit_of_measurement="%",
+            state_class="measurement",
+        ),
+    ]
+    return {component["unique_id"]: component for component in sensors}
+
+
 def _disk_components(
     hostname: str,
     disk_paths: tuple[str, ...] | list[str],
@@ -257,6 +284,7 @@ def build_discovery_payload(
     hostname: str,
     disk_paths: tuple[str, ...] | list[str],
     *,
+    has_fan: bool = False,
     sw_version: str = __version__,
 ) -> dict[str, Any]:
     """Build a retained MQTT device-discovery payload for pi_stats.
@@ -265,6 +293,7 @@ def build_discovery_payload(
         hostname: Pi hostname used in topics and unique IDs.
         disk_paths: Filesystem paths that appear under `disk_usage` in the state
             payload.
+        has_fan: When True, include pwmfan RPM/PWM sensors.
         sw_version: Software version advertised in the discovery origin/device.
 
     Returns:
@@ -272,6 +301,8 @@ def build_discovery_payload(
     """
     components = _fixed_components(hostname)
     components.update(_disk_components(hostname, disk_paths))
+    if has_fan:
+        components.update(_fan_components(hostname))
 
     return {
         "dev": {
@@ -300,6 +331,7 @@ def build_discovery_updates(
     disk_paths: tuple[str, ...] | list[str],
     previous_component_ids: set[str] | frozenset[str],
     *,
+    has_fan: bool = False,
     sw_version: str = __version__,
 ) -> tuple[dict[str, Any], ...]:
     """Build the ordered discovery payloads needed to update a device.
@@ -312,6 +344,7 @@ def build_discovery_updates(
         hostname: Pi hostname used in topics and unique IDs.
         disk_paths: Currently configured filesystem paths.
         previous_component_ids: Component IDs published by the previous run.
+        has_fan: When True, include pwmfan RPM/PWM sensors.
         sw_version: Software version advertised in the discovery origin/device.
 
     Returns:
@@ -321,6 +354,7 @@ def build_discovery_updates(
     clean_payload = build_discovery_payload(
         hostname,
         disk_paths,
+        has_fan=has_fan,
         sw_version=sw_version,
     )
     current_component_ids = set(clean_payload["cmps"])

--- a/src/services/pi_stats/main.py
+++ b/src/services/pi_stats/main.py
@@ -12,7 +12,7 @@ from os import getenv, getloadavg
 from pathlib import Path
 from threading import Event
 from time import sleep, time
-from typing import TYPE_CHECKING, ClassVar, Final, TypedDict
+from typing import TYPE_CHECKING, ClassVar, Final, NotRequired, TypedDict
 
 import psutil
 from wg_utilities.decorators import process_exception
@@ -45,6 +45,8 @@ LOGGER = get_streaming_logger(__name__)
 
 IP_FALLBACK: Final = f"{mqtt.HOSTNAME}.local"
 ONE_MINUTE: Final = 60
+HWMON_ROOT: Final = Path("/sys/class/hwmon")
+PWM_MAX_DUTY: Final = 255
 
 SERVICE_START_TIME: Final = datetime.now(UTC).isoformat()
 
@@ -67,6 +69,7 @@ PUBLISH_TIMEOUT_SECONDS: Final = 5
 # Set from on_connect; consumed on the main thread so wait_for_publish cannot deadlock
 # the Paho network loop.
 _DISCOVERY_NEEDED: Final = Event()
+_FAN_READ_ERRORS_LOGGED: Final[set[str]] = set()
 
 
 class Stats(TypedDict):
@@ -86,6 +89,64 @@ class Stats(TypedDict):
     local_ip: str
     service_start_time: str
     wg_scripts_version: str
+    fan_speed_rpm: NotRequired[int]
+    fan_pwm_percent: NotRequired[float]
+
+
+@dataclass(frozen=True, slots=True)
+class PwmFanHwmon:
+    """Sysfs paths for a detected Pi 5 pwmfan hwmon device."""
+
+    fan_input: Path
+    pwm: Path
+
+
+@lru_cache(maxsize=1)
+def find_pwmfan_hwmon() -> PwmFanHwmon | None:
+    """Locate the Pi 5 Active Cooler pwmfan hwmon device, if present."""
+    if not HWMON_ROOT.is_dir():
+        return None
+
+    for hwmon in sorted(HWMON_ROOT.glob("hwmon*")):
+        try:
+            name = (hwmon / "name").read_text(encoding="utf-8").strip()
+        except OSError:
+            continue
+
+        if name != "pwmfan":
+            continue
+
+        fan_input = hwmon / "fan1_input"
+        pwm = hwmon / "pwm1"
+        if fan_input.is_file() and pwm.is_file():
+            LOGGER.info("Detected pwmfan hwmon at %s", hwmon)
+            return PwmFanHwmon(fan_input=fan_input, pwm=pwm)
+
+    return None
+
+
+def read_fan_stats() -> tuple[int, float] | None:
+    """Read fan RPM and PWM duty percent from pwmfan, if available.
+
+    Returns:
+        tuple[int, float] | None: ``(rpm, pwm_percent)`` when readable, otherwise
+        ``None`` (no pwmfan, or a read failure for this sample).
+    """
+    hwmon = find_pwmfan_hwmon()
+    if hwmon is None:
+        return None
+
+    try:
+        rpm = int(hwmon.fan_input.read_text(encoding="utf-8").strip())
+        pwm_raw = int(hwmon.pwm.read_text(encoding="utf-8").strip())
+    except (OSError, ValueError) as exc:
+        error_key = type(exc).__name__
+        if error_key not in _FAN_READ_ERRORS_LOGGED:
+            _FAN_READ_ERRORS_LOGGED.add(error_key)
+            LOGGER.exception("Failed to read pwmfan stats")
+        return None
+
+    return rpm, float(round(pwm_raw / PWM_MAX_DUTY * 100, 1))
 
 
 @lru_cache(maxsize=1)
@@ -165,22 +226,29 @@ class RaspberryPi:
 
         self.get_count += 1
 
-        return Stats(
-            cpu_usage=cpu_usage,
-            memory_usage=memory_usage,
-            temperature=temperature,
-            disk_usage=self.disk_usage,
-            load_1m=load_1m,
-            load_5m=load_5m,
-            load_15m=load_15m,
-            uptime=uptime,
-            boot_time=self.boot_time_iso,
-            local_git_ref=local_git_ref(),
-            active_git_ref=self.ACTIVE_GIT_REF,
-            local_ip=local_ip(),
-            service_start_time=SERVICE_START_TIME,
-            wg_scripts_version=__version__,
-        )
+        stats: Stats = {
+            "cpu_usage": cpu_usage,
+            "memory_usage": memory_usage,
+            "temperature": temperature,
+            "disk_usage": self.disk_usage,
+            "load_1m": load_1m,
+            "load_5m": load_5m,
+            "load_15m": load_15m,
+            "uptime": uptime,
+            "boot_time": self.boot_time_iso,
+            "local_git_ref": local_git_ref(),
+            "active_git_ref": self.ACTIVE_GIT_REF,
+            "local_ip": local_ip(),
+            "service_start_time": SERVICE_START_TIME,
+            "wg_scripts_version": __version__,
+        }
+
+        if (fan_stats := read_fan_stats()) is not None:
+            fan_speed_rpm, fan_pwm_percent = fan_stats
+            stats["fan_speed_rpm"] = fan_speed_rpm
+            stats["fan_pwm_percent"] = fan_pwm_percent
+
+        return stats
 
     @property
     def cpu_temp(self) -> float:
@@ -264,6 +332,7 @@ def publish_discovery(client: Client) -> None:
         mqtt.HOSTNAME,
         DISK_USAGE_PATHS,
         previous_component_ids,
+        has_fan=find_pwmfan_hwmon() is not None,
     )
 
     for payload in payloads:


### PR DESCRIPTION


---



- 433f0de | feat: Add Pi 5 pwmfan RPM and PWM monitoring
- 3991632 | docs: Document fan speed and PWM metrics


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Raspberry Pi 5 fan monitoring, including fan speed (RPM) and PWM percentage.
  * Home Assistant now automatically discovers fan speed and PWM sensors when supported hardware is detected.
  * Published statistics include fan readings when available.

* **Documentation**
  * Updated Pi Stats documentation with the new fan metrics and discovery behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->