### PR TITLE
feat: Add SMART disk monitoring with sudo setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@ just setup              # sync all dependency groups
 just run mqtt_gpio      # run a service locally
 just sync               # runtime deps only (Pi deploy)
 just update             # switch to main, ff-only pull, sync, restart
-just deploy 1.3.1       # dirty-check, checkout tag (detached), sync, restart
+just deploy 1.3.1          # dirty-check, checkout tag/branch (detached), sync, restart
+just deploy feature/smart  # same for a remote branch tip
 just setup-tailscale KEY  # install Tailscale and join the tailnet
 just setup-deploy-key FILE_OR_LINE  # install CI deploy SSH public key
 ```

--- a/justfile
+++ b/justfile
@@ -180,7 +180,7 @@ restart-all:
     done
 
 # Pull latest main, sync runtime deps, and restart installed services.
-# After `just deploy <tag>` (detached HEAD), this switches back to main first.
+# After `just deploy <ref>` (detached HEAD), this switches back to main first.
 update:
     #!/usr/bin/env bash
     set -euo pipefail
@@ -254,17 +254,40 @@ setup-deploy-key key:
         echo "Installed deploy key into ~/.ssh/authorized_keys"
     fi
 
-# Checkout a release tag (detached), sync runtime deps, and restart services.
+# Checkout a tag or branch (detached), sync runtime deps, and restart services.
 # Rejects a dirty tree. Use `just update` later to return to main and pull.
-deploy tag:
+# Examples:
+#   just deploy 2.1.4
+#   just deploy feature/smart
+deploy ref:
     #!/usr/bin/env bash
     set -euo pipefail
+    if [[ -z "{{ ref }}" ]]; then
+        echo "Usage: just deploy <tag-or-branch>" >&2
+        exit 1
+    fi
     if ! git diff --quiet || ! git diff --cached --quiet \
         || [[ -n "$(git ls-files --others --exclude-standard)" ]]; then
         echo "Working tree is dirty; commit or stash changes before deploying." >&2
         exit 1
     fi
-    git fetch --tags origin
-    git switch --detach "{{ tag }}"
+
+    git fetch --prune --tags origin
+
+    target=""
+    if git rev-parse --verify --quiet "refs/remotes/origin/{{ ref }}" >/dev/null; then
+        target="origin/{{ ref }}"
+    elif git rev-parse --verify --quiet "refs/tags/{{ ref }}" >/dev/null; then
+        target="{{ ref }}"
+    elif git rev-parse --verify --quiet "{{ ref }}" >/dev/null; then
+        target="{{ ref }}"
+    else
+        echo "Unknown ref after fetch: {{ ref }}" >&2
+        echo "Expected a remote branch (origin/{{ ref }}) or a tag." >&2
+        exit 1
+    fi
+
+    echo "Deploying ${target} ($(git rev-parse --short "${target}"))"
+    git switch --detach "${target}"
     just sync
     just restart-all

--- a/justfile
+++ b/justfile
@@ -86,6 +86,39 @@ setup-service service:
     just enable {{ service }}
     just restart {{ service }}
 
+# Grant passwordless smartctl for pi_stats (requires: sudo apt install smartmontools)
+setup-smart:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    service_user="${SUDO_USER:-$(id -un)}"
+    destination="/etc/sudoers.d/pi_stats-smartctl"
+    smartctl_path="/usr/sbin/smartctl"
+
+    if [[ ! -x "${smartctl_path}" ]]; then
+        echo "smartctl not found at ${smartctl_path}." >&2
+        echo "Install it first: sudo apt install smartmontools" >&2
+        exit 1
+    fi
+
+    if [[ "${service_user}" == *[!A-Za-z0-9_.-]* ]]; then
+        echo "Unsupported service user for sudoers: ${service_user}" >&2
+        exit 1
+    fi
+
+    rendered="$(mktemp)"
+    trap 'rm -f "$rendered"' EXIT
+    printf '%s ALL=(root) NOPASSWD: %s\n' "${service_user}" "${smartctl_path}" > "${rendered}"
+    chmod 0440 "${rendered}"
+
+    if ! visudo -cf "${rendered}" >/dev/null; then
+        echo "Generated sudoers snippet failed visudo validation" >&2
+        exit 1
+    fi
+
+    sudo install -m 0440 "${rendered}" "${destination}"
+    echo "Installed ${destination} for user ${service_user}"
+    echo "Restart pi_stats to pick up SMART disks: just restart pi_stats"
+
 [private]
 _services:
     #!/usr/bin/env bash

--- a/src/services/pi_stats/README.md
+++ b/src/services/pi_stats/README.md
@@ -113,14 +113,17 @@ Disk entity IDs use path slugs:
 | `/home` | `sensor.<hostname>_disk_usage_home` |
 | `/mnt/storage` | `sensor.<hostname>_disk_usage_mnt_storage` |
 
-SMART entity IDs use device-path slugs (`/dev/sda` → `dev_sda`):
+SMART entity IDs use device-path slugs (`/dev/sda` → `dev_sda`) for stability.
+Friendly names come from smartctl `model_name` (for example
+`Samsung SSD 850 EVO 500GB`); identical models are disambiguated with the
+device basename.
 
-| Metric | Entity ID |
-|--------|-----------|
-| Health | `binary_sensor.<hostname>_smart_dev_sda_health` |
-| Temperature | `sensor.<hostname>_smart_dev_sda_temperature` |
-| Reallocated sectors (ATA) | `sensor.<hostname>_smart_dev_sda_reallocated_sectors` |
-| SSD wear (NVMe) | `sensor.<hostname>_smart_dev_nvme0_percentage_used` |
+| Metric | Entity ID | Example name |
+|--------|-----------|--------------|
+| Health | `binary_sensor.<hostname>_smart_dev_sda_health` | SMART Health (Samsung SSD 850 EVO 500GB) |
+| Temperature | `sensor.<hostname>_smart_dev_sda_temperature` | SMART Temperature (Samsung SSD 850 EVO 500GB) |
+| Reallocated sectors (ATA) | `sensor.<hostname>_smart_dev_sda_reallocated_sectors` | Reallocated Sectors (Samsung SSD 850 EVO 500GB) |
+| SSD wear (NVMe) | `sensor.<hostname>_smart_dev_nvme0_percentage_used` | SSD Wear (SSD98-2563CG-PB) |
 
 Health uses `device_class: problem` (`on` = `FAILED`). Duplicate normalized path
 slugs are rejected at startup.

--- a/src/services/pi_stats/README.md
+++ b/src/services/pi_stats/README.md
@@ -78,6 +78,10 @@ SMART is sampled every five minutes (not every stats cycle). The entire `smart`
 key is omitted on SD-only hosts, when `smartmontools` is missing, or when the
 service user cannot run `smartctl` via sudo.
 
+Detection uses `smartctl --scan-open` plus a `/sys/block` fallback that probes
+common USB-SATA transports (`sat`, …). That covers bridges smartctl does not
+auto-detect (for example JMicron `0x152d:0xa578` on vaultpi).
+
 #### Enabling SMART on a Pi
 
 1. Install tools: `sudo apt install smartmontools`

--- a/src/services/pi_stats/README.md
+++ b/src/services/pi_stats/README.md
@@ -44,6 +44,49 @@ payload also includes:
 These keys are omitted entirely on hosts without `pwmfan` (and for a sample if the
 sysfs read fails).
 
+### SMART disks (optional)
+
+When `smartctl` can enumerate and probe SMART-capable disks (NVMe / SATA SSD /
+HDD — not SD cards), the payload includes a nested `smart` map keyed by device
+slug:
+
+```json
+{
+  "smart": {
+    "dev_sda": {
+      "health": "PASSED",
+      "temperature": 38,
+      "reallocated_sectors": 0
+    },
+    "dev_nvme0": {
+      "health": "PASSED",
+      "temperature": 41,
+      "percentage_used": 2
+    }
+  }
+}
+```
+
+| Key | Disks | Meaning |
+|-----|-------|---------|
+| `health` | All | `PASSED` / `FAILED` from SMART overall-health |
+| `temperature` | All (when reported) | Drive temperature in °C |
+| `reallocated_sectors` | ATA/SATA | Max of attributes 5 and 197 (reallocated / pending) |
+| `percentage_used` | NVMe | SSD wear estimate from the NVMe health log |
+
+SMART is sampled every five minutes (not every stats cycle). The entire `smart`
+key is omitted on SD-only hosts, when `smartmontools` is missing, or when the
+service user cannot run `smartctl` via sudo.
+
+#### Enabling SMART on a Pi
+
+1. Install tools: `sudo apt install smartmontools`
+2. Grant the service user passwordless `smartctl`: `just setup-smart`
+3. Restart the service: `just restart pi_stats`
+
+`setup-smart` installs `/etc/sudoers.d/pi_stats-smartctl` (validated with
+`visudo`) so the non-root service can run `sudo -n /usr/sbin/smartctl`.
+
 ## MQTT Discovery
 
 On connect, `pi_stats` publishes a retained device-discovery payload to:
@@ -56,6 +99,7 @@ That creates one Home Assistant device containing:
   `sensor.<hostname>_wg_scripts_version`, etc.)
 - One disk-usage sensor per `DISK_USAGE_PATHS` entry
 - Fan Speed / Fan PWM sensors when `pwmfan` hwmon is detected at startup
+- Per SMART disk (when detected): health binary sensor, temperature, and wear
 
 Disk entity IDs use path slugs:
 
@@ -65,11 +109,22 @@ Disk entity IDs use path slugs:
 | `/home` | `sensor.<hostname>_disk_usage_home` |
 | `/mnt/storage` | `sensor.<hostname>_disk_usage_mnt_storage` |
 
-Duplicate normalized path slugs are rejected at startup.
+SMART entity IDs use device-path slugs (`/dev/sda` → `dev_sda`):
+
+| Metric | Entity ID |
+|--------|-----------|
+| Health | `binary_sensor.<hostname>_smart_dev_sda_health` |
+| Temperature | `sensor.<hostname>_smart_dev_sda_temperature` |
+| Reallocated sectors (ATA) | `sensor.<hostname>_smart_dev_sda_reallocated_sectors` |
+| SSD wear (NVMe) | `sensor.<hostname>_smart_dev_nvme0_percentage_used` |
+
+Health uses `device_class: problem` (`on` = `FAILED`). Duplicate normalized path
+slugs are rejected at startup.
 
 Discovery is republished after every MQTT connection and reconnection. Previously
-published component IDs are stored locally so removing a disk path first publishes
-the Home Assistant removal tombstone, then the clean discovery payload.
+published component IDs (and platforms) are stored locally so removing a disk path
+or SMART device first publishes the Home Assistant removal tombstone, then the
+clean discovery payload.
 
 ## Availability
 

--- a/src/services/pi_stats/discovery.py
+++ b/src/services/pi_stats/discovery.py
@@ -28,6 +28,7 @@ class SmartDevice:
     transport: str
     kind: SmartKind
     slug: str
+    label: str
 
 
 def path_to_slug(path: str) -> str:
@@ -333,12 +334,13 @@ def _smart_components(
     for device in devices:
         jinja_slug = device.slug.replace("\\", "\\\\").replace("'", "\\'")
         smart_path = f"value_json.smart['{jinja_slug}']"
+        label = device.label
 
         health_metric = f"smart_{device.slug}_health"
         components[f"{hostname}_{health_metric}"] = _binary_sensor_component(
             hostname=hostname,
             metric=health_metric,
-            name=f"SMART Health ({device.device})",
+            name=f"SMART Health ({label})",
             value_template=f"{{{{ {smart_path}.health }}}}",
             icon="mdi:harddisk-plus",
             force_update=True,
@@ -351,7 +353,7 @@ def _smart_components(
         components[f"{hostname}_{temperature_metric}"] = _sensor_component(
             hostname=hostname,
             metric=temperature_metric,
-            name=f"SMART Temperature ({device.device})",
+            name=f"SMART Temperature ({label})",
             value_template=f"{{{{ {smart_path}.temperature }}}}",
             icon="mdi:thermometer",
             force_update=True,
@@ -365,7 +367,7 @@ def _smart_components(
             components[f"{hostname}_{wear_metric}"] = _sensor_component(
                 hostname=hostname,
                 metric=wear_metric,
-                name=f"SSD Wear ({device.device})",
+                name=f"SSD Wear ({label})",
                 value_template=f"{{{{ {smart_path}.percentage_used }}}}",
                 icon="mdi:battery-heart-variant",
                 force_update=True,
@@ -377,7 +379,7 @@ def _smart_components(
             components[f"{hostname}_{wear_metric}"] = _sensor_component(
                 hostname=hostname,
                 metric=wear_metric,
-                name=f"Reallocated Sectors ({device.device})",
+                name=f"Reallocated Sectors ({label})",
                 value_template=f"{{{{ {smart_path}.reallocated_sectors }}}}",
                 icon="mdi:harddisk-remove",
                 force_update=True,

--- a/src/services/pi_stats/discovery.py
+++ b/src/services/pi_stats/discovery.py
@@ -3,10 +3,12 @@
 from __future__ import annotations
 
 import re
+from dataclasses import dataclass
 from json import JSONDecodeError, dumps, loads
-from typing import TYPE_CHECKING, Any, Final
+from typing import TYPE_CHECKING, Any, Final, Literal
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
     from pathlib import Path
 
 from wg_scripts import __version__
@@ -15,6 +17,17 @@ DISCOVERY_PREFIX: Final = "homeassistant"
 PAYLOAD_ONLINE: Final = "online"
 PAYLOAD_OFFLINE: Final = "offline"
 NON_ALPHANUMERIC: Final = re.compile(r"[^a-z0-9]+")
+SmartKind = Literal["ata", "nvme"]
+
+
+@dataclass(frozen=True, slots=True)
+class SmartDevice:
+    """A SMART-capable block device detected for optional pi_stats sensors."""
+
+    device: str
+    transport: str
+    kind: SmartKind
+    slug: str
 
 
 def path_to_slug(path: str) -> str:
@@ -95,6 +108,36 @@ def _sensor_component(
         component["unit_of_measurement"] = unit_of_measurement
     if state_class is not None:
         component["state_class"] = state_class
+    if device_class is not None:
+        component["device_class"] = device_class
+    return component
+
+
+def _binary_sensor_component(
+    *,
+    hostname: str,
+    metric: str,
+    name: str,
+    value_template: str,
+    icon: str,
+    force_update: bool,
+    payload_on: str,
+    payload_off: str,
+    device_class: str | None = None,
+) -> dict[str, Any]:
+    """Build one MQTT binary_sensor component config."""
+    unique_id = f"{hostname}_{metric}"
+    component: dict[str, Any] = {
+        "p": "binary_sensor",
+        "name": name,
+        "unique_id": unique_id,
+        "default_entity_id": f"binary_sensor.{unique_id}",
+        "icon": icon,
+        "force_update": force_update,
+        "value_template": value_template,
+        "payload_on": payload_on,
+        "payload_off": payload_off,
+    }
     if device_class is not None:
         component["device_class"] = device_class
     return component
@@ -280,11 +323,76 @@ def _disk_components(
     return components
 
 
+def _smart_components(
+    hostname: str,
+    devices: Sequence[SmartDevice],
+) -> dict[str, dict[str, Any]]:
+    """Build SMART health/temperature/wear sensors for detected disks."""
+    components: dict[str, dict[str, Any]] = {}
+
+    for device in devices:
+        jinja_slug = device.slug.replace("\\", "\\\\").replace("'", "\\'")
+        smart_path = f"value_json.smart['{jinja_slug}']"
+
+        health_metric = f"smart_{device.slug}_health"
+        components[f"{hostname}_{health_metric}"] = _binary_sensor_component(
+            hostname=hostname,
+            metric=health_metric,
+            name=f"SMART Health ({device.device})",
+            value_template=f"{{{{ {smart_path}.health }}}}",
+            icon="mdi:harddisk-plus",
+            force_update=True,
+            payload_on="FAILED",
+            payload_off="PASSED",
+            device_class="problem",
+        )
+
+        temperature_metric = f"smart_{device.slug}_temperature"
+        components[f"{hostname}_{temperature_metric}"] = _sensor_component(
+            hostname=hostname,
+            metric=temperature_metric,
+            name=f"SMART Temperature ({device.device})",
+            value_template=f"{{{{ {smart_path}.temperature }}}}",
+            icon="mdi:thermometer",
+            force_update=True,
+            unit_of_measurement="°C",
+            state_class="measurement",
+            device_class="temperature",
+        )
+
+        if device.kind == "nvme":
+            wear_metric = f"smart_{device.slug}_percentage_used"
+            components[f"{hostname}_{wear_metric}"] = _sensor_component(
+                hostname=hostname,
+                metric=wear_metric,
+                name=f"SSD Wear ({device.device})",
+                value_template=f"{{{{ {smart_path}.percentage_used }}}}",
+                icon="mdi:battery-heart-variant",
+                force_update=True,
+                unit_of_measurement="%",
+                state_class="measurement",
+            )
+        else:
+            wear_metric = f"smart_{device.slug}_reallocated_sectors"
+            components[f"{hostname}_{wear_metric}"] = _sensor_component(
+                hostname=hostname,
+                metric=wear_metric,
+                name=f"Reallocated Sectors ({device.device})",
+                value_template=f"{{{{ {smart_path}.reallocated_sectors }}}}",
+                icon="mdi:harddisk-remove",
+                force_update=True,
+                state_class="measurement",
+            )
+
+    return components
+
+
 def build_discovery_payload(
     hostname: str,
     disk_paths: tuple[str, ...] | list[str],
     *,
     has_fan: bool = False,
+    smart_devices: Sequence[SmartDevice] = (),
     sw_version: str = __version__,
 ) -> dict[str, Any]:
     """Build a retained MQTT device-discovery payload for pi_stats.
@@ -294,6 +402,7 @@ def build_discovery_payload(
         disk_paths: Filesystem paths that appear under `disk_usage` in the state
             payload.
         has_fan: When True, include pwmfan RPM/PWM sensors.
+        smart_devices: SMART-capable disks to expose as optional sensors.
         sw_version: Software version advertised in the discovery origin/device.
 
     Returns:
@@ -303,6 +412,8 @@ def build_discovery_payload(
     components.update(_disk_components(hostname, disk_paths))
     if has_fan:
         components.update(_fan_components(hostname))
+    if smart_devices:
+        components.update(_smart_components(hostname, smart_devices))
 
     return {
         "dev": {
@@ -329,9 +440,10 @@ def build_discovery_payload(
 def build_discovery_updates(
     hostname: str,
     disk_paths: tuple[str, ...] | list[str],
-    previous_component_ids: set[str] | frozenset[str],
+    previous_component_ids: set[str] | frozenset[str] | dict[str, str],
     *,
     has_fan: bool = False,
+    smart_devices: Sequence[SmartDevice] = (),
     sw_version: str = __version__,
 ) -> tuple[dict[str, Any], ...]:
     """Build the ordered discovery payloads needed to update a device.
@@ -343,8 +455,10 @@ def build_discovery_updates(
     Args:
         hostname: Pi hostname used in topics and unique IDs.
         disk_paths: Currently configured filesystem paths.
-        previous_component_ids: Component IDs published by the previous run.
+        previous_component_ids: Component IDs (or ID -> platform map) published by
+            the previous run.
         has_fan: When True, include pwmfan RPM/PWM sensors.
+        smart_devices: SMART-capable disks to expose as optional sensors.
         sw_version: Software version advertised in the discovery origin/device.
 
     Returns:
@@ -355,10 +469,18 @@ def build_discovery_updates(
         hostname,
         disk_paths,
         has_fan=has_fan,
+        smart_devices=smart_devices,
         sw_version=sw_version,
     )
     current_component_ids = set(clean_payload["cmps"])
-    removed_component_ids = previous_component_ids - current_component_ids
+    if isinstance(previous_component_ids, dict):
+        previous_platforms = previous_component_ids
+        previous_ids = set(previous_platforms)
+    else:
+        previous_ids = set(previous_component_ids)
+        previous_platforms = dict.fromkeys(previous_ids, "sensor")
+
+    removed_component_ids = previous_ids - current_component_ids
 
     if not removed_component_ids:
         return (clean_payload,)
@@ -368,7 +490,9 @@ def build_discovery_updates(
         "cmps": {
             **clean_payload["cmps"],
             **{
-                component_id: {"p": "sensor"}
+                component_id: {
+                    "p": previous_platforms.get(component_id, "sensor"),
+                }
                 for component_id in sorted(removed_component_ids)
             },
         },
@@ -381,20 +505,43 @@ def load_component_ids(path: Path) -> set[str]:
 
     Invalid or missing state is treated as no previous publication.
     """
+    return set(load_component_platforms(path))
+
+
+def load_component_platforms(path: Path) -> dict[str, str]:
+    """Load component ID -> MQTT platform from a previous discovery publication.
+
+    Supports the legacy list-of-IDs format (assumed ``sensor``) and the current
+    object map of ID to platform. Invalid or missing state is treated as empty.
+    """
     try:
         value = loads(path.read_text(encoding="utf-8"))
     except FileNotFoundError, JSONDecodeError, OSError:
-        return set()
+        return {}
 
-    if not isinstance(value, list) or not all(isinstance(item, str) for item in value):
-        return set()
+    if isinstance(value, list) and all(isinstance(item, str) for item in value):
+        return dict.fromkeys(value, "sensor")
 
-    return set(value)
+    if isinstance(value, dict) and all(
+        isinstance(key, str) and isinstance(platform, str)
+        for key, platform in value.items()
+    ):
+        return dict(value)
+
+    return {}
 
 
 def save_component_ids(path: Path, component_ids: set[str]) -> None:
-    """Atomically persist the component IDs from a discovery publication."""
+    """Atomically persist component IDs as sensors (legacy helper)."""
+    save_component_platforms(path, dict.fromkeys(sorted(component_ids), "sensor"))
+
+
+def save_component_platforms(path: Path, component_platforms: dict[str, str]) -> None:
+    """Atomically persist component ID -> MQTT platform from a discovery publication."""
     path.parent.mkdir(parents=True, exist_ok=True)
     temporary_path = path.with_suffix(f"{path.suffix}.tmp")
-    temporary_path.write_text(dumps(sorted(component_ids)), encoding="utf-8")
+    temporary_path.write_text(
+        dumps(dict(sorted(component_platforms.items()))),
+        encoding="utf-8",
+    )
     temporary_path.replace(path)

--- a/src/services/pi_stats/main.py
+++ b/src/services/pi_stats/main.py
@@ -7,9 +7,10 @@ from contextlib import suppress
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from functools import lru_cache
-from json import dumps
+from json import JSONDecodeError, dumps, loads
 from os import getenv, getloadavg
 from pathlib import Path
+from subprocess import run  # noqa: S404
 from threading import Event
 from time import sleep, time
 from typing import TYPE_CHECKING, ClassVar, Final, NotRequired, TypedDict
@@ -23,12 +24,15 @@ from wg_utilities.utils import mqtt
 from services.pi_stats.discovery import (
     PAYLOAD_OFFLINE,
     PAYLOAD_ONLINE,
+    SmartDevice,
+    SmartKind,
     availability_topic,
     build_discovery_updates,
     discovery_topic,
     disk_path_slugs,
-    load_component_ids,
-    save_component_ids,
+    load_component_platforms,
+    path_to_slug,
+    save_component_platforms,
     stats_topic,
 )
 from wg_scripts import __version__
@@ -47,6 +51,8 @@ IP_FALLBACK: Final = f"{mqtt.HOSTNAME}.local"
 ONE_MINUTE: Final = 60
 HWMON_ROOT: Final = Path("/sys/class/hwmon")
 PWM_MAX_DUTY: Final = 255
+SMARTCTL: Final = "/usr/sbin/smartctl"
+ATA_WEAR_ATTRIBUTE_IDS: Final = frozenset({5, 197})
 
 SERVICE_START_TIME: Final = datetime.now(UTC).isoformat()
 
@@ -70,6 +76,16 @@ PUBLISH_TIMEOUT_SECONDS: Final = 5
 # the Paho network loop.
 _DISCOVERY_NEEDED: Final = Event()
 _FAN_READ_ERRORS_LOGGED: Final[set[str]] = set()
+_SMART_READ_ERRORS_LOGGED: Final[set[str]] = set()
+
+
+class SmartDeviceStats(TypedDict):
+    """Per-disk SMART sample included under ``Stats.smart``."""
+
+    health: str
+    temperature: NotRequired[float]
+    reallocated_sectors: NotRequired[int]
+    percentage_used: NotRequired[int]
 
 
 class Stats(TypedDict):
@@ -91,6 +107,7 @@ class Stats(TypedDict):
     wg_scripts_version: str
     fan_speed_rpm: NotRequired[int]
     fan_pwm_percent: NotRequired[float]
+    smart: NotRequired[dict[str, SmartDeviceStats]]
 
 
 @dataclass(frozen=True, slots=True)
@@ -149,6 +166,263 @@ def read_fan_stats() -> tuple[int, float] | None:
     return rpm, float(round(pwm_raw / PWM_MAX_DUTY * 100, 1))
 
 
+def _run_smartctl(*args: str) -> dict[str, object] | None:
+    """Run ``sudo -n smartctl`` with JSON output, returning parsed stdout.
+
+    ``smartctl`` uses a bitmask exit status even on successful reads, so non-zero
+    exits are ignored when valid JSON is returned. Missing binary, sudo denial,
+    or unparsable output all yield ``None`` without treating the exit code as fatal.
+    """
+    cmd = ["sudo", "-n", SMARTCTL, *args]
+    try:
+        completed = run(  # noqa: S603
+            cmd,
+            capture_output=True,
+            check=False,
+            text=True,
+        )
+    except FileNotFoundError, PermissionError:
+        LOGGER.debug("smartctl unavailable (%s)", SMARTCTL)
+        return None
+    except OSError:
+        LOGGER.exception("Failed to invoke smartctl")
+        return None
+
+    output = completed.stdout.strip()
+    if not output:
+        error = completed.stderr.strip()
+        if error:
+            LOGGER.debug("smartctl produced no output: %s", error)
+        return None
+
+    try:
+        payload = loads(output)
+    except JSONDecodeError:
+        LOGGER.debug("smartctl returned non-JSON output: %s", output[:200])
+        return None
+
+    if not isinstance(payload, dict):
+        return None
+
+    return payload
+
+
+def _smart_kind(device: str, transport: str, probe: dict[str, object]) -> SmartKind:
+    """Classify a SMART device as ATA or NVMe from probe data / transport."""
+    if "nvme_smart_health_information_log" in probe:
+        return "nvme"
+    if "ata_smart_attributes" in probe:
+        return "ata"
+    if "nvme" in transport.casefold() or "nvme" in device.casefold():
+        return "nvme"
+    return "ata"
+
+
+@lru_cache(maxsize=1)
+def find_smart_devices() -> tuple[SmartDevice, ...]:
+    """Detect SMART-capable disks via ``smartctl --scan-open``.
+
+    Returns an empty tuple when smartctl is missing, sudo is denied, the host is
+    SD-only, or no scanned device answers a health probe.
+    """
+    scan = _run_smartctl("--scan-open", "-j")
+    if scan is None:
+        return ()
+
+    raw_devices = scan.get("devices")
+    if not isinstance(raw_devices, list):
+        return ()
+
+    detected: list[SmartDevice] = []
+    seen_slugs: set[str] = set()
+
+    for entry in raw_devices:
+        if not isinstance(entry, dict):
+            continue
+
+        name = entry.get("name")
+        transport = entry.get("type")
+        if not isinstance(name, str) or not isinstance(transport, str):
+            continue
+
+        probe = _run_smartctl("-d", transport, "-H", "-j", name)
+        if probe is None or "smart_status" not in probe:
+            continue
+
+        kind = _smart_kind(name, transport, probe)
+        slug = path_to_slug(name)
+        if slug in seen_slugs:
+            LOGGER.warning(
+                "Skipping SMART device %s due to slug collision on %r",
+                name,
+                slug,
+            )
+            continue
+
+        seen_slugs.add(slug)
+        detected.append(
+            SmartDevice(
+                device=name,
+                transport=transport,
+                kind=kind,
+                slug=slug,
+            ),
+        )
+
+    if detected:
+        LOGGER.info(
+            "Detected SMART devices: %s",
+            ", ".join(
+                f"{device.device} ({device.kind}/{device.transport})"
+                for device in detected
+            ),
+        )
+
+    return tuple(detected)
+
+
+def _ata_wear_sectors(probe: dict[str, object]) -> int | None:
+    """Return max(reallocated, pending) from ATA attributes 5 and 197."""
+    attributes = probe.get("ata_smart_attributes")
+    if not isinstance(attributes, dict):
+        return None
+
+    table = attributes.get("table")
+    if not isinstance(table, list):
+        return None
+
+    candidates: list[int] = []
+    for row in table:
+        if not isinstance(row, dict):
+            continue
+        attr_id = row.get("id")
+        if attr_id not in ATA_WEAR_ATTRIBUTE_IDS:
+            continue
+        raw = row.get("raw")
+        if not isinstance(raw, dict):
+            continue
+        value = raw.get("value")
+        if isinstance(value, bool) or not isinstance(value, int):
+            continue
+        candidates.append(value)
+
+    return max(candidates) if candidates else None
+
+
+def _as_float(value: object) -> float | None:
+    """Coerce a JSON number to float, rejecting bools."""
+    if isinstance(value, bool) or not isinstance(value, int | float):
+        return None
+    return float(value)
+
+
+def _as_int(value: object) -> int | None:
+    """Coerce a JSON number to int, rejecting bools."""
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float):
+        return int(value)
+    return None
+
+
+def _probe_temperature(probe: dict[str, object]) -> float | None:
+    """Read ``temperature.current`` from a smartctl JSON probe."""
+    temperature = probe.get("temperature")
+    if not isinstance(temperature, dict):
+        return None
+    return _as_float(temperature.get("current"))
+
+
+def _nvme_percentage_used(probe: dict[str, object]) -> int | None:
+    """Read NVMe ``percentage_used`` from a smartctl JSON probe."""
+    nvme_log = probe.get("nvme_smart_health_information_log")
+    if not isinstance(nvme_log, dict):
+        return None
+    return _as_int(nvme_log.get("percentage_used"))
+
+
+def _parse_smart_device_stats(
+    device: SmartDevice,
+    probe: dict[str, object],
+) -> SmartDeviceStats | None:
+    """Extract the curated SMART fields for one device sample."""
+    smart_status = probe.get("smart_status")
+    if not isinstance(smart_status, dict) or "passed" not in smart_status:
+        return None
+
+    passed = smart_status.get("passed")
+    if not isinstance(passed, bool):
+        return None
+
+    stats: SmartDeviceStats = {
+        "health": "PASSED" if passed else "FAILED",
+    }
+
+    if (temperature := _probe_temperature(probe)) is not None:
+        stats["temperature"] = temperature
+
+    if device.kind == "nvme":
+        if (percentage_used := _nvme_percentage_used(probe)) is not None:
+            stats["percentage_used"] = percentage_used
+    elif (wear := _ata_wear_sectors(probe)) is not None:
+        stats["reallocated_sectors"] = wear
+
+    return stats
+
+
+def read_smart_stats(
+    devices: tuple[SmartDevice, ...] | None = None,
+) -> dict[str, SmartDeviceStats]:
+    """Read curated SMART stats for each detected (or provided) device.
+
+    Devices that fail for a sample are omitted; the first failure of each type is
+    logged, matching the pwmfan error-dedupe pattern.
+    """
+    targets = find_smart_devices() if devices is None else devices
+    results: dict[str, SmartDeviceStats] = {}
+
+    for device in targets:
+        try:
+            probe = _run_smartctl(
+                "-d",
+                device.transport,
+                "-A",
+                "-H",
+                "-j",
+                device.device,
+            )
+        except Exception as exc:
+            error_key = f"{device.device}:{type(exc).__name__}"
+            if error_key not in _SMART_READ_ERRORS_LOGGED:
+                _SMART_READ_ERRORS_LOGGED.add(error_key)
+                LOGGER.exception("Failed to read SMART stats for %s", device.device)
+            continue
+
+        if probe is None:
+            error_key = f"{device.device}:NoOutput"
+            if error_key not in _SMART_READ_ERRORS_LOGGED:
+                _SMART_READ_ERRORS_LOGGED.add(error_key)
+                LOGGER.warning("SMART read for %s returned no usable JSON", device.device)
+            continue
+
+        parsed = _parse_smart_device_stats(device, probe)
+        if parsed is None:
+            error_key = f"{device.device}:MissingStatus"
+            if error_key not in _SMART_READ_ERRORS_LOGGED:
+                _SMART_READ_ERRORS_LOGGED.add(error_key)
+                LOGGER.warning(
+                    "SMART probe for %s missing smart_status.passed",
+                    device.device,
+                )
+            continue
+
+        results[device.slug] = parsed
+
+    return results
+
+
 @lru_cache(maxsize=1)
 def local_git_ref() -> str:
     """Get the current git ref for the local repo."""
@@ -194,6 +468,7 @@ class RaspberryPi:
     boot_time_iso: str = field(init=False)
 
     get_count: int = 0
+    smart_cache: dict[str, SmartDeviceStats] = field(default_factory=dict)
 
     def get_stats(self) -> Stats:
         """Get the current stats for the Pi.
@@ -212,7 +487,8 @@ class RaspberryPi:
             self.uptime,
         )
 
-        if self.get_count % 5 == 0:
+        refresh_slow = self.get_count % 5 == 0
+        if refresh_slow:
             local_git_ref.cache_clear()
             local_ip.cache_clear()
 
@@ -247,6 +523,12 @@ class RaspberryPi:
             fan_speed_rpm, fan_pwm_percent = fan_stats
             stats["fan_speed_rpm"] = fan_speed_rpm
             stats["fan_pwm_percent"] = fan_pwm_percent
+
+        smart_devices = find_smart_devices()
+        if smart_devices:
+            if refresh_slow or not self.smart_cache:
+                self.smart_cache = read_smart_stats(smart_devices)
+            stats["smart"] = self.smart_cache
 
         return stats
 
@@ -327,12 +609,13 @@ def publish_discovery(client: Client) -> None:
     processed by the network loop, so ``wait_for_publish`` from ``on_connect``
     would deadlock.
     """
-    previous_component_ids = load_component_ids(DISCOVERY_STATE_PATH)
+    previous_component_platforms = load_component_platforms(DISCOVERY_STATE_PATH)
     payloads = build_discovery_updates(
         mqtt.HOSTNAME,
         DISK_USAGE_PATHS,
-        previous_component_ids,
+        previous_component_platforms,
         has_fan=find_pwmfan_hwmon() is not None,
+        smart_devices=find_smart_devices(),
     )
 
     for payload in payloads:
@@ -349,8 +632,11 @@ def publish_discovery(client: Client) -> None:
             )
 
     clean_payload = payloads[-1]
-    component_ids = set(clean_payload["cmps"])
-    save_component_ids(DISCOVERY_STATE_PATH, component_ids)
+    component_platforms = {
+        component_id: str(component.get("p", "sensor"))
+        for component_id, component in clean_payload["cmps"].items()
+    }
+    save_component_platforms(DISCOVERY_STATE_PATH, component_platforms)
     LOGGER.info(
         "Published MQTT discovery for %s (%d components, %d updates) to %s",
         mqtt.HOSTNAME,

--- a/src/services/pi_stats/main.py
+++ b/src/services/pi_stats/main.py
@@ -263,7 +263,10 @@ def _probe_smart_device(
     name: str,
     preferred_transport: str | None = None,
 ) -> tuple[str, dict[str, object]] | None:
-    """Probe a device with preferred then fallback transports until SMART answers."""
+    """Probe a device with preferred then fallback transports until SMART answers.
+
+    Uses ``-i -H`` so identity (model name) is available alongside health.
+    """
     transports: list[str] = []
     if preferred_transport:
         transports.append(preferred_transport)
@@ -277,11 +280,96 @@ def _probe_smart_device(
         if transport in tried:
             continue
         tried.add(transport)
-        probe = _run_smartctl("-d", transport, "-H", "-j", name)
+        probe = _run_smartctl("-d", transport, "-i", "-H", "-j", name)
         if probe is not None and "smart_status" in probe:
             return transport, probe
 
     return None
+
+
+def _smart_label(probe: dict[str, object], device: str) -> str:
+    """Best-effort friendly disk name from smartctl identity fields."""
+    for key in ("model_name", "scsi_model_name"):
+        value = probe.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return device
+
+
+def _disambiguate_smart_labels(devices: list[SmartDevice]) -> list[SmartDevice]:
+    """Append the device basename when multiple disks share a model label."""
+    label_counts: dict[str, int] = {}
+    for device in devices:
+        label_counts[device.label] = label_counts.get(device.label, 0) + 1
+
+    if all(count == 1 for count in label_counts.values()):
+        return devices
+
+    return [
+        SmartDevice(
+            device=device.device,
+            transport=device.transport,
+            kind=device.kind,
+            slug=device.slug,
+            label=(
+                device.label
+                if label_counts[device.label] == 1
+                else f"{device.label} ({Path(device.device).name})"
+            ),
+        )
+        for device in devices
+    ]
+
+
+def _scan_open_candidates() -> list[tuple[str, str | None]] | None:
+    """Return ``(device, transport)`` pairs from ``smartctl --scan-open``.
+
+    Returns ``None`` when smartctl cannot be invoked; an empty list when it can
+    but found no devices.
+    """
+    scan = _run_smartctl("--scan-open", "-j")
+    if scan is None:
+        return None
+
+    candidates: list[tuple[str, str | None]] = []
+    seen_names: set[str] = set()
+    raw_devices = scan.get("devices")
+    if not isinstance(raw_devices, list):
+        return candidates
+
+    for entry in raw_devices:
+        if not isinstance(entry, dict):
+            continue
+        name = entry.get("name")
+        transport = entry.get("type")
+        if not isinstance(name, str) or not isinstance(transport, str):
+            continue
+        if name in seen_names:
+            continue
+        seen_names.add(name)
+        candidates.append((name, transport))
+
+    return candidates
+
+
+def _smart_candidates() -> list[tuple[str, str | None]] | None:
+    """Merge scan-open and ``/sys/block`` candidates.
+
+    Returns ``None`` when smartctl cannot be invoked at all.
+    """
+    scan_candidates = _scan_open_candidates()
+    if scan_candidates is None:
+        return None
+
+    candidates = list(scan_candidates)
+    seen_names = {name for name, _transport in candidates}
+    for name in _block_device_candidates():
+        if name in seen_names:
+            continue
+        seen_names.add(name)
+        candidates.append((name, None))
+
+    return candidates
 
 
 @lru_cache(maxsize=1)
@@ -293,32 +381,9 @@ def find_smart_devices() -> tuple[SmartDevice, ...]:
     common transports. Returns an empty tuple when smartctl is missing, sudo is
     denied, or nothing answers a health probe (e.g. SD-only Pis).
     """
-    scan = _run_smartctl("--scan-open", "-j")
-    if scan is None:
+    candidates = _smart_candidates()
+    if candidates is None:
         return ()
-
-    candidates: list[tuple[str, str | None]] = []
-    seen_names: set[str] = set()
-
-    raw_devices = scan.get("devices")
-    if isinstance(raw_devices, list):
-        for entry in raw_devices:
-            if not isinstance(entry, dict):
-                continue
-            name = entry.get("name")
-            transport = entry.get("type")
-            if not isinstance(name, str) or not isinstance(transport, str):
-                continue
-            if name in seen_names:
-                continue
-            seen_names.add(name)
-            candidates.append((name, transport))
-
-    for name in _block_device_candidates():
-        if name in seen_names:
-            continue
-        seen_names.add(name)
-        candidates.append((name, None))
 
     detected: list[SmartDevice] = []
     seen_slugs: set[str] = set()
@@ -346,14 +411,17 @@ def find_smart_devices() -> tuple[SmartDevice, ...]:
                 transport=transport,
                 kind=kind,
                 slug=slug,
+                label=_smart_label(probe, name),
             ),
         )
+
+    detected = _disambiguate_smart_labels(detected)
 
     if detected:
         LOGGER.info(
             "Detected SMART devices: %s",
             ", ".join(
-                f"{device.device} ({device.kind}/{device.transport})"
+                f"{device.label} [{device.device} {device.kind}/{device.transport}]"
                 for device in detected
             ),
         )

--- a/src/services/pi_stats/main.py
+++ b/src/services/pi_stats/main.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 import socket
 from contextlib import suppress
 from dataclasses import dataclass, field
@@ -53,6 +54,17 @@ HWMON_ROOT: Final = Path("/sys/class/hwmon")
 PWM_MAX_DUTY: Final = 255
 SMARTCTL: Final = "/usr/sbin/smartctl"
 ATA_WEAR_ATTRIBUTE_IDS: Final = frozenset({5, 197})
+# Prefer sat first: common for USB-SATA bridges that smartctl --scan-open skips
+# (e.g. JMicron 0x152d:0xa578 on vaultpi).
+SMART_TRANSPORT_FALLBACKS: Final = (
+    "sat",
+    "sat,12",
+    "sat,16",
+    "scsi",
+    "usbjmicron",
+    "auto",
+)
+NVME_NAMESPACE: Final = re.compile(r"^(nvme\d+)n\d+$")
 
 SERVICE_START_TIME: Final = datetime.now(UTC).isoformat()
 
@@ -218,37 +230,105 @@ def _smart_kind(device: str, transport: str, probe: dict[str, object]) -> SmartK
     return "ata"
 
 
+def _block_device_candidates() -> tuple[str, ...]:
+    """Return whole-disk device nodes that may support SMART.
+
+    Skips loop/zram/ram/dm/md and mmc (SD/eMMC). NVMe namespaces are mapped to
+    the controller node (``/dev/nvme0n1`` → ``/dev/nvme0``) to match smartctl
+    ``--scan-open``.
+    """
+    sys_block = Path("/sys/block")
+    if not sys_block.is_dir():
+        return ()
+
+    devices: list[str] = []
+    seen: set[str] = set()
+
+    for entry in sorted(sys_block.iterdir()):
+        name = entry.name
+        if name.startswith(("loop", "ram", "zram", "dm-", "md", "mmcblk")):
+            continue
+
+        nvme_match = NVME_NAMESPACE.fullmatch(name)
+        device = f"/dev/{nvme_match.group(1)}" if nvme_match else f"/dev/{name}"
+        if device in seen or not Path(device).exists():
+            continue
+        seen.add(device)
+        devices.append(device)
+
+    return tuple(devices)
+
+
+def _probe_smart_device(
+    name: str,
+    preferred_transport: str | None = None,
+) -> tuple[str, dict[str, object]] | None:
+    """Probe a device with preferred then fallback transports until SMART answers."""
+    transports: list[str] = []
+    if preferred_transport:
+        transports.append(preferred_transport)
+    if "nvme" in name.casefold():
+        transports.append("nvme")
+    else:
+        transports.extend(SMART_TRANSPORT_FALLBACKS)
+
+    tried: set[str] = set()
+    for transport in transports:
+        if transport in tried:
+            continue
+        tried.add(transport)
+        probe = _run_smartctl("-d", transport, "-H", "-j", name)
+        if probe is not None and "smart_status" in probe:
+            return transport, probe
+
+    return None
+
+
 @lru_cache(maxsize=1)
 def find_smart_devices() -> tuple[SmartDevice, ...]:
-    """Detect SMART-capable disks via ``smartctl --scan-open``.
+    """Detect SMART-capable disks via scan-open plus block-device fallbacks.
 
-    Returns an empty tuple when smartctl is missing, sudo is denied, the host is
-    SD-only, or no scanned device answers a health probe.
+    ``smartctl --scan-open`` misses some USB-SATA bridges (unknown VID:PID). For
+    those, whole disks from ``/sys/block`` are probed with ``-d sat`` and other
+    common transports. Returns an empty tuple when smartctl is missing, sudo is
+    denied, or nothing answers a health probe (e.g. SD-only Pis).
     """
     scan = _run_smartctl("--scan-open", "-j")
     if scan is None:
         return ()
 
+    candidates: list[tuple[str, str | None]] = []
+    seen_names: set[str] = set()
+
     raw_devices = scan.get("devices")
-    if not isinstance(raw_devices, list):
-        return ()
+    if isinstance(raw_devices, list):
+        for entry in raw_devices:
+            if not isinstance(entry, dict):
+                continue
+            name = entry.get("name")
+            transport = entry.get("type")
+            if not isinstance(name, str) or not isinstance(transport, str):
+                continue
+            if name in seen_names:
+                continue
+            seen_names.add(name)
+            candidates.append((name, transport))
+
+    for name in _block_device_candidates():
+        if name in seen_names:
+            continue
+        seen_names.add(name)
+        candidates.append((name, None))
 
     detected: list[SmartDevice] = []
     seen_slugs: set[str] = set()
 
-    for entry in raw_devices:
-        if not isinstance(entry, dict):
+    for name, preferred_transport in candidates:
+        probed = _probe_smart_device(name, preferred_transport)
+        if probed is None:
             continue
 
-        name = entry.get("name")
-        transport = entry.get("type")
-        if not isinstance(name, str) or not isinstance(transport, str):
-            continue
-
-        probe = _run_smartctl("-d", transport, "-H", "-j", name)
-        if probe is None or "smart_status" not in probe:
-            continue
-
+        transport, probe = probed
         kind = _smart_kind(name, transport, probe)
         slug = path_to_slug(name)
         if slug in seen_slugs:


### PR DESCRIPTION


---



- dd6dfb4 | feat: Add SMART disk monitoring with sudo setup
- 41c786e | feat: Update deploy command to support branch refs
- 9ca7355 | feat: Enhance SMART detection on USB-SATA bridges
- a0892b9 | feat: Improve SMART feature with friendly names


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional SMART disk monitoring, including health, temperature, and wear metrics.
  * Added SMART sensors to Home Assistant MQTT Discovery with stable names and cleanup when devices change.
  * Added `setup-smart` to configure passwordless SMART access safely.
  * Deployment commands now support tags and branch references.

* **Documentation**
  * Expanded deployment and SMART monitoring setup and behavior documentation.

* **Bug Fixes**
  * Removed MQTT Discovery components using the correct sensor platform.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->